### PR TITLE
foundry-voting: improve devx of merkle tree recalculation

### DIFF
--- a/foundry-voting/README.md
+++ b/foundry-voting/README.md
@@ -31,4 +31,4 @@ See the test file [here](./test/zkVote.t.sol). Run tests with `forge test`.
 
 If you change the circuit at `./circuits/src/main.nr` you will need to recompile (`nargo compile p`) the circuit and regenerate the Solidity verifier (saved to `./circuits/contract/plonk_vk.sol`).
 
-The merkle tree will need to be recalculated whenever there are users added to the set or if there are any changes to the voters private keys (private keys are an input to the merkle membership commitment, so changing a key changes the corresponding leaf in the merkle tree, which changes the root).
+The merkle tree will need to be recalculated whenever there are users added to the set or if there are any changes to the voters private keys (private keys are an input to the merkle membership commitment, so changing a key changes the corresponding leaf in the merkle tree, which changes the root). See `test_build_merkle_tree` for an example calculation.

--- a/foundry-voting/circuits/src/main.nr
+++ b/foundry-voting/circuits/src/main.nr
@@ -11,18 +11,24 @@ fn main(root : pub Field, index : Field, hash_path : [Field; 2], secret: Field, 
     nullifier[0]
 }
 
-// helpers for getting note_commitments to build the merkle tree
+// Helpers for getting note_commitments to build the merkle tree.
+// To view: nargo test --show-output
 
-// fn main(priv_key : Field, secret : Field) {
-//     let note_commitment = std::hash::pedersen([priv_key, secret]);
-//     std::println("Public leaf:");
-//     std::println(note_commitment);
-// }
+#[test]
+fn test_build_merkle_tree() {
+    let secret = 9;
+    let commitment_0 =  std::hash::pedersen([0, secret])[0];
+    let commitment_1 =  std::hash::pedersen([1, secret])[0];
+    let commitment_2 =  std::hash::pedersen([2, secret])[0];
+    let commitment_3 =  std::hash::pedersen([3, secret])[0];
 
-// get hashes for building a merkle tree
+    let left_branch = std::hash::pedersen([commitment_0, commitment_1])[0];
+    let right_branch = std::hash::pedersen([commitment_2, commitment_3])[0];
 
-// fn main(first : Field, second : Field) {
-//     let note_commitment = std::hash::pedersen([first, second]);
-//     std::println("Public node:");
-//     std::println(note_commitment);
-// }
+    let root = std::hash::pedersen([left_branch, right_branch])[0];
+
+    std::println("Merkle Tree:");
+    std::println([root]);
+    std::println([left_branch, right_branch]);
+    std::println([commitment_0, commitment_1, commitment_2, commitment_3]);
+}


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

In the foundry-voting example, a lot of the merkle tree related fields are hardcoded, and a solid chunk of the README is dedicated to walking through how a dev might go about recalculating them.

The commented out functions in the circuit were a good starting point, but still kinda clunky to change the whole set.


## Summary\*

<!-- Describe the changes in this PR, particularly breaking changes if any. -->

This PR sets out to make it easier for a beginner to recalculate the merkle tree in a single command. While also demonstrating noir's testing functionality.

```
$ nargo test --show-output

Running 1 test functions...
Testing test_build_merkle_tree...
Merkle Tree:
0x20c77d6d51119d86868b3a37a64cd4510abd7bdb7f62a9e78e51fe8ca615a194
[0x0fcf7577aeb374ed0a19b942e0470521d46bde86f01d3138239ccc4b995c00ae, 0x1e8e7c1e1f6f65d0d3553e0f715c335f0ccdcc21cda1df7355e6c6e851bccf54]
[0x0ae5f55a6f2c82f74bba34d9e23c7cd69d41c183c8ddbd9a440ee3de5bf1c649, 0x1053e87bed5f2a4f5144b386c5403701212f4b3c21cb14683b6ebdfed16c854d, 0x1eff4379fbc748b53a07ce5961c24eccdfeb8f17154490d2e41c6096a9519329, 0x0e0adf2416341b3d868d88043127be8e6965f3758ce6a80d11a494fe21b0cdff]
ok
All tests passed
```


# PR Checklist\*

- [x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
