### PR TITLE
Multiple runs for automated test fails due to bug in the createFile.sh script

### DIFF
--- a/with-foundry/script/createFile.sh
+++ b/with-foundry/script/createFile.sh
@@ -10,5 +10,5 @@ fi
 
 cp ./circuits/Nargo.toml /tmp/$1/Nargo.toml
 cp ./circuits/Verifier.toml /tmp/$1/Verifier.toml
-cp -r ./circuits/src /tmp/$1/src
+cp -r ./circuits/src /tmp/$1/
 echo "" > /tmp/$1/Prover.toml && echo "File created"


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description
Fixed a bug which caused src directory to be copied into the src directory causing a pattern like /src/src.

## Problem\*
Failing after multiple runs, because src directory was copied into src
<!-- Describe the problem this Pull Request (PR) resolves / link to the GitHub Issue that describes the problem. -->

Resolves <!-- Link to GitHub Issue -->

## Summary\*
I changed the createFile.sh and removed the path /tmp$1/src to be /tmp/$1, as the src will be copied there by the command.
<!-- Describe the changes in this PR. -->
<!-- Supplement code examples and highlight breaking changes, if applicable. -->

## Additional Context

<!-- Supplement further information if applicable. -->

# PR Checklist\*

- [ x] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
