### PR TITLE
Fixed bug where datatypes are strings instead of numbers, this works …

### DIFF
--- a/next-hardhat/components/component.tsx
+++ b/next-hardhat/components/component.tsx
@@ -8,7 +8,7 @@ import { NoirBrowser } from '../utils/noir/noirBrowser';
 import { ThreeDots } from 'react-loader-spinner';
 
 function Component() {
-  const [input, setInput] = useState({ x: '', y: '' });
+  const [input, setInput] = useState({ x: 0, y: 0});
   const [pending, setPending] = useState(false);
   const [proof, setProof] = useState(Uint8Array.from([]));
   const [verification, setVerification] = useState(false);
@@ -89,8 +89,8 @@ function Component() {
       <h1>Example starter</h1>
       <h2>This circuit checks that x and y are different</h2>
       <p>Try it!</p>
-      <input name="x" type={'text'} onChange={handleChange} value={input.x} />
-      <input name="y" type={'text'} onChange={handleChange} value={input.y} />
+      <input name="x" type={'number'} onChange={handleChange} value={input.x} />
+      <input name="y" type={'number'} onChange={handleChange} value={input.y} />
       <button onClick={calculateProof}>Calculate proof</button>
       {pending && <ThreeDots wrapperClass="spinner" color="#000000" height={100} width={100} />}
     </div>

--- a/next-hardhat/utils/noir/noirNode.ts
+++ b/next-hardhat/utils/noir/noirNode.ts
@@ -45,7 +45,7 @@ export class NoirNode {
     this.acirComposer = await this.api.acirNewAcirComposer(subgroupSize);
   }
 
-  async generateWitness(input: any, acirBuffer: Buffer): Promise<Uint8Array> {
+  async generateWitness(input: any): Promise<Uint8Array> {
     const initialWitness = new Map<number, string>();
     initialWitness.set(1, ethers.utils.hexZeroPad(`0x${input.x.toString(16)}`, 32));
     initialWitness.set(2, ethers.utils.hexZeroPad(`0x${input.y.toString(16)}`, 32));


### PR DESCRIPTION
…fine with the given circuit example; however, this doesn't work when we want to perform operations

# Description

## Problem\*

There is a difference between number.toString(16) and string.toString(16). A user who clones the repository may not know the difference and may use the component.ts file as reference. However, the user may face constraint errors since they wouldn't be able to perform their regular mathematical operations. This works for the demo circuit because we are just checking for non-equality, but would not work for another mathematical operation (e.g. multiplication).

Also removed unused parameter in function in NoirNode.

## Summary\*

Changed the input from String type to Number type.

## Additional Context

:)

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
