### PR TITLE
Change name for acvm

### DIFF
--- a/next-hardhat/package.json
+++ b/next-hardhat/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@aztec/bb.js": "0.3.6",
-    "@noir-lang/acvm_js": "git+https://git@github.com/noir-lang/acvm-simulator-wasm.git#b9d9ca9dfc5140839f23998d9466307215607c42",
+    "@noir-lang/acvm_js": "git+https://git@github.com/noir-lang/acvm-js-wasm.git#b9d9ca9dfc5140839f23998d9466307215607c42",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomicfoundation/hardhat-network-helpers": "^1.0.0",
     "@nomicfoundation/hardhat-toolbox": "^2.0.1",


### PR DESCRIPTION
<!-- Thanks for taking the time to improve Noir! -->
<!-- Please fill out all fields marked with an asterisk (*). -->

# Description

## Problem\*

Unable to install acvm with `yarn`

## Summary\*

Running `yarn` will give you ~"invalid checksum".

## Additional Context

I think it is needed because of this commit: https://github.com/noir-lang/acvm-js-wasm/commit/1f4cba63b37b004bcaecb28c8bddc1d801727d6a

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
