### PR TITLE
quick fix for permissions

### DIFF
--- a/with-foundry/foundry.toml
+++ b/with-foundry/foundry.toml
@@ -2,7 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-fs_permissions = [{ access = "read-write", path = "./"},{ access = "read-write", path = "/tmp/"}]
+fs_permissions = [{ access = "read-write", path = "./"}]
 ffi = true
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/with-foundry/script/Verify.s.sol
+++ b/with-foundry/script/Verify.s.sol
@@ -17,7 +17,7 @@ contract VerifyScript is Script {
         verifier = new UltraVerifier();
         starter = new Starter(verifier);
 
-        string memory proof = vm.readLine("./circuits/proofs/p.proof");
+        string memory proof = vm.readLine("./circuits/proofs/with_foundry.proof");
         bytes memory proofBytes = vm.parseBytes(proof);
 
         bytes32[] memory correct = new bytes32[](1);

--- a/with-foundry/script/cleanup.sh
+++ b/with-foundry/script/cleanup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ "$#" -ne 1 ]
+then
+  echo "Usage: ./cleanup.sh [TESTNAME_STRING]"
+  exit 1
+fi
+
+rm -rf ./tmp
+echo "Cleaned up tests"

--- a/with-foundry/script/createFile.sh
+++ b/with-foundry/script/createFile.sh
@@ -4,11 +4,11 @@ then
   echo "Usage: ./createFile.sh [TESTNAME_STRING]"
   exit 1
 fi
-if [ ! -d "/tmp/$1" ]; then
-  mkdir /tmp/$1
+if [ ! -d "./tmp/$1" ]; then
+  mkdir -p ./tmp/$1
 fi
 
-cp ./circuits/Nargo.toml /tmp/$1/Nargo.toml
-cp ./circuits/Verifier.toml /tmp/$1/Verifier.toml
-cp -r ./circuits/src /tmp/$1/
-echo "" > /tmp/$1/Prover.toml && echo "File created"
+cp ./circuits/Nargo.toml ./tmp/$1/Nargo.toml
+cp ./circuits/Verifier.toml ./tmp/$1/Verifier.toml
+cp -r ./circuits/src ./tmp/$1/
+echo "" > ./tmp/$1/Prover.toml && echo "File created"

--- a/with-foundry/script/prove.sh
+++ b/with-foundry/script/prove.sh
@@ -4,4 +4,4 @@ then
   echo "Usage: ./prove.sh [TESTNAME_STRING]"
   exit 1
 fi
-cd /tmp/$1 && nargo prove && echo "Proof Generated"
+cd ./tmp/$1 && nargo prove && echo "Proof Generated"

--- a/with-foundry/test/Starter.t.sol
+++ b/with-foundry/test/Starter.t.sol
@@ -34,6 +34,7 @@ contract StarterTest is Test {
     }
 
     function test_dynamicProof() public {
+        string memory testName = "test1";
         string[] memory _fieldNames = new string[](2);
         string[] memory _fieldValues = new string[](2);
 
@@ -44,11 +45,13 @@ contract StarterTest is Test {
 
         // Set expected dynamic proof outcome
         dynamicCorrect[0] = bytes32(0x0000000000000000000000000000000000000000000000000000000000000005);
-        bytes memory proofBytes = generateDynamicProof("test1", _fieldNames, _fieldValues);
+        bytes memory proofBytes = generateDynamicProof(testName, _fieldNames, _fieldValues);
         starter.verifyEqual(proofBytes, dynamicCorrect);
+        cleanup(testName);
     }
 
     function test_dynamicProofSecondTest() public {
+        string memory testName = "test2";
         string[] memory _fieldNames = new string[](2);
         string[] memory _fieldValues = new string[](2);
 
@@ -59,11 +62,14 @@ contract StarterTest is Test {
 
         // Set expected dynamic proof outcome
         dynamicCorrect[0] = bytes32(0x0000000000000000000000000000000000000000000000000000000000000008);
-        bytes memory proofBytes = generateDynamicProof("test2", _fieldNames, _fieldValues);
+        bytes memory proofBytes = generateDynamicProof(testName, _fieldNames, _fieldValues);
         starter.verifyEqual(proofBytes, dynamicCorrect);
+        cleanup(testName);
+
     }
 
     function test_dynamicProofThirdTest() public {
+        string memory testName = "test3";
         string[] memory _fieldNames = new string[](2);
         string[] memory _fieldValues = new string[](2);
 
@@ -74,8 +80,9 @@ contract StarterTest is Test {
 
         // Set expected dynamic proof outcome
         dynamicCorrect[0] = bytes32(0x0000000000000000000000000000000000000000000000000000000000000007);
-        bytes memory proofBytes = generateDynamicProof("test3", _fieldNames, _fieldValues);
+        bytes memory proofBytes = generateDynamicProof(testName, _fieldNames, _fieldValues);
         starter.verifyEqual(proofBytes, dynamicCorrect);
+        cleanup(testName);
     }
 
     /// @dev This function generates dynamic proofs using 2 scripts in the /script directory
@@ -96,7 +103,7 @@ contract StarterTest is Test {
         bytes memory fileCreateResponse = vm.ffi(filecreateCommand);
         console.log(string(fileCreateResponse));
 
-        string memory _file = string.concat("/tmp/", _testName, "/Prover.toml");
+        string memory _file = string.concat("./tmp/", _testName, "/Prover.toml");
         vm.writeFile(_file, "");
         for (uint256 i; i < _fields.length; i++) {
             vm.writeLine(_file, string.concat(_fields[i], " = ", _fieldValues[i]));
@@ -108,7 +115,15 @@ contract StarterTest is Test {
         ffi_command[1] = _testName;
         bytes memory commandResponse = vm.ffi(ffi_command);
         console.log(string(commandResponse));
-        string memory _newProof = vm.readLine(string.concat("/tmp/", _testName, "/proofs/with_foundry.proof"));
+        string memory _newProof = vm.readLine(string.concat("./tmp/", _testName, "/proofs/with_foundry.proof"));
         return vm.parseBytes(_newProof);
+    }
+
+    function cleanup(string memory _testName) public {
+        string[] memory cleanupCommand = new string[] (2);
+        cleanupCommand[0] = "./script/cleanup.sh";
+        cleanupCommand[1] = _testName;
+        bytes memory cleanupResponse = vm.ffi(cleanupCommand);
+        console.log(string(cleanupResponse));
     }
 }


### PR DESCRIPTION
Foundry was writing in `/tmp` which is an OS directory, and in some machines it doesn't have permissions to do so apparently.

Made some changes to make the `tmp` dir be created on the parent folder (the `with_foundry` folder), and a script to clean it up after tests pass.