### PR TITLE
adding pagination to get more buried releases, removes testing for prereleases

### DIFF
--- a/.github/scripts/latest.js
+++ b/.github/scripts/latest.js
@@ -1,28 +1,55 @@
 const { writeFileSync } = require('fs');
 
+const GITHUB_PAGES = 3;
+
 async function main() {
   const fetchOpts = {
+    params: { per_page: 100 },
     headers: {},
   };
 
   if (process.env.GITHUB_TOKEN)
     fetchOpts.headers = { Authorization: `token ${process.env.GITHUB_TOKEN}` };
 
-  const res = await fetch('https://api.github.com/repos/noir-lang/noir/releases', fetchOpts);
+  const versions = [];
+  for (let i = 0; i < GITHUB_PAGES; i++) {
+    const res = await fetch(
+      `https://api.github.com/repos/noir-lang/noir/releases?page=${i + 1}`,
+      fetchOpts,
+    );
 
-  const data = await res.json();
+    const data = await res.json();
 
-  const filtered = data.filter(
-    release => !release.tag_name.includes('aztec') && !release.tag_name.includes('nightly'),
-  );
+    const filtered = data.filter(
+      release => !release.tag_name.includes('aztec') && !release.tag_name.includes('nightly'),
+    );
+    versions.push(...filtered);
+  }
 
-  const latestStable = filtered.find(release => !release.prerelease).tag_name.substring(1);
-  const latestPreRelease = filtered.find(release => release.prerelease).tag_name.substring(1);
+  const latestStable = versions.find(release => !release.prerelease).tag_name.substring(1);
 
-  // TODO: add the prerelease to this object!
+  /**
+   * TODO: test the prerelease!
+   *
+   * The problem with the prerelease is that if the test runs for both the stable and the prerelease,
+   * and the prerelease has a breaking change, then the stable will fail.
+   *
+   * If we update the the starter to match the prerelease, then the stable will fail.
+   *
+   * This means that if there is a breaking change in a prerelease, we will ALWAYS get a warning 😄, which defeats the purpose.
+   *
+   * A solution would be to have a separate "prerelease" branch that is updated with the prerelease. And the CI runs on that branch.
+   * However, Noir hasn't yet reached a state where, for example, there is ALWAYS a prerelease newer than the stable.
+   * Sometimes the stable is the last one, and there is a prerelease buried somewhere that never got the honor of being promoted to stable.
+   *
+   * So for now, we will just ignore the prerelease.
+   */
+
+  // const latestPreRelease = versions.find(release => release.prerelease).tag_name.substring(1);
+
   const workflowOutput = JSON.stringify({
     stable: latestStable,
-    prerelease: latestPreRelease,
+    // prerelease: latestPreRelease,
   });
   console.log(workflowOutput); // DON'T REMOVE, GITHUB WILL CAPTURE THIS OUTPUT
 }


### PR DESCRIPTION
# Added some pagination 

CI was failing because it didn't get any releases, and the reason for that is that there are SO MANY `aztecs` that it can't really find anything.

This should get us 300 releases. This should get us pretty much every release in existence.

# Removed the prereleases

Left a comment in the code, as the code could look a little bit over-engineered and I don't want that reputation 😄

(I'm joking, but yeah I found out we don't have a stable release cycle, for example at this point in time, stable is 0.22.0 and prerelease is... 0.21.0... so it would be a totally useless and misleading test)