### PR TITLE
fix: update broken links to Noir docs

### DIFF
--- a/vite-hardhat/README.md
+++ b/vite-hardhat/README.md
@@ -17,7 +17,7 @@ In the meantime, follow these simple steps to work on your own machine:
 
 2. Install [Node.js >20.10 (latest LTS)](https://nodejs.org/en) (tested on v18.17.0)
 
-3. Install [noirup](https://noir-lang.org/getting_started/nargo_installation/#option-1-noirup) with
+3. Install [noirup](https://noir-lang.org/docs/getting_started/installation/#installing-noirup) with
 
    ```bash
    curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash

--- a/with-foundry/README.md
+++ b/with-foundry/README.md
@@ -10,9 +10,9 @@ Want to get started in a pinch? Start your project in a free Github Codespace!
 
 In the meantime, follow these simple steps to work on your own machine:
 
-Install [noirup](https://noir-lang.org/getting_started/nargo_installation/#option-1-noirup) with
+Install [noirup](https://noir-lang.org/docs/getting_started/installation/#installing-noirup) with
 
-1. Install [noirup](https://noir-lang.org/getting_started/nargo_installation/#option-1-noirup):
+1. Install [noirup](https://noir-lang.org/docs/getting_started/installation/#installing-noirup):
 
    ```bash
    curl -L https://raw.githubusercontent.com/noir-lang/noirup/main/install | bash


### PR DESCRIPTION
# Description

Update broken links to Noir docs.

## Problem\*

I've found several broken link to Noir Docs. This PR fixes the issues


## Summary\*

...

## Additional Context

...

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
