### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/with_foundry.yaml
+++ b/.github/workflows/with_foundry.yaml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected