### PR TITLE
Update GitHub Actions versions 

### DIFF
--- a/.github/workflows/vite_hardhat.yaml
+++ b/.github/workflows/vite_hardhat.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
 
       - name: Get latest version
         id: versions_step

--- a/.github/workflows/with_foundry.yaml
+++ b/.github/workflows/with_foundry.yaml
@@ -12,7 +12,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
 


### PR DESCRIPTION
Changes
actions/checkout@v2 → actions/checkout@v4
oven-sh/setup-bun@v1 → oven-sh/setup-bun@v2

Files Changed
.github/workflows/vite_hardhat.yaml
.github/workflows/with_foundry.yaml

Release Notes
https://github.com/oven-sh/setup-bun/releases/tag/v2.0.2
https://github.com/actions/checkout/releases/tag/v4.2.2

This update brings improvements to the Bun setup action including better path resolution, enhanced caching mechanisms, and improved version handling. The checkout action update ensures the latest security patches and performance improvements.