### PR TITLE
CI: migrate workflows to checkout v5

### DIFF
--- a/.github/workflows/vite_hardhat.yaml
+++ b/.github/workflows/vite_hardhat.yaml
@@ -12,7 +12,7 @@ jobs:
         working-directory: vite-hardhat
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0